### PR TITLE
Add etude management to the VPO (issue #36)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev --port 5005",
+        "dev": "next dev --port 5005 --turbopack",
         "build": "next build",
         "start": "next start",
         "lint": "next lint",

--- a/src/components/meta-components/searchbar.tsx
+++ b/src/components/meta-components/searchbar.tsx
@@ -63,9 +63,9 @@ export function SearchBar<T extends { toString(): string }>({
             <div className={cn('group relative flex flex-row', className)}>
                 <Label
                     className={cn(
-                        'absolute left-2 top-4 bg-box-background w-fit px-1 text-lg line-h leading-4 rounded-md whitespace-nowrap pointer-events-none transition-all overflow-ellipsis overflow-hidden z-10',
+                        'absolute left-2 top-2 bg-box-background w-fit px-1 text-lg line-h leading-5 rounded-md whitespace-nowrap pointer-events-none transition-all overflow-ellipsis overflow-hidden z-10',
                         (search ?? '').toString() !== '' && 'left-2 -top-2',
-                        'group-focus-within:left-2 group-focus-within:-top-2 group-focus-within:max-w-none'
+                        'group-focus-within:left-2 group-focus-within:-top-3 group-focus-within:max-w-none'
                     )}
                     htmlFor={id}
                 >


### PR DESCRIPTION
This PR will add the pages and features to allow the VPO to access and manage every etudes

It will add the option to the sidebar on the left. The page would display the etudes and selecting one would let you access either the parameters or the suivi de l'étude just like the cdp of said etude.