### PR TITLE
fix(github): remove duplication in PR runs and fix compulsory commit naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
     push:
         branches:
             - '*'
-    pull_request:
-        branches:
-            - '*'
 
 jobs:
     build:

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -44,4 +44,4 @@ jobs:
 
             - uses: webiny/action-conventional-commits@v1.3.0
               with:
-                  allowed-commit-types: 'feat,fix,chore,docs,style,refactor,perf,test'
+                  allowed-commit-types: 'feat,fix,chore,docs,style,ref,perf,test'

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -4,9 +4,6 @@ on:
     push:
         branches:
             - '*'
-    pull_request:
-        branches:
-            - '*'
 
 jobs:
     pr-lint:
@@ -36,7 +33,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: wagoid/commitlint-github-action@v5
 
-    build:
+    fmt-lint:
         name: Conventional Commits
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,9 +4,6 @@ on:
     push:
         branches:
             - '*'
-    pull_request:
-        branches:
-            - '*'
 
 jobs:
     lint:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -4,9 +4,6 @@ on:
     push:
         branches:
             - '*'
-    pull_request:
-        branches:
-            - '*'
 
 jobs:
     prettier:

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -4,9 +4,6 @@ on:
     push:
         branches:
             - '*'
-    pull_request:
-        branches:
-            - '*'
 
 jobs:
     knip:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Jet Centre: Telecom Etude Centralised Tool
+# Jet-Centre: Telecom Etude Centralised Tool
 
 ![License](https://img.shields.io/github/license/telecom-etude/jet-centre)
 ![Issues](https://img.shields.io/github/issues/telecom-etude/jet-centre)
@@ -19,18 +19,18 @@
 
 ## Overview
 
-Jet Centre is an ERP-CRM for [Telecom Etude](https://telecom-etude.fr), the Junior-Entreprise of [Télécom Paris](https://telecom-paris.fr).
+Jet-Centre is an ERP-CRM for [Telecom Etude](https://telecom-etude.fr), the Junior-Entreprise of [Télécom Paris](https://telecom-paris.fr).
 It allows the Telecom Etude's administrators to manage more easily and proficiently their missions and their projects within the Junior-Enterprise.
 
 This is a centralised app that will allow CDP to enter once the data, and see it mirrored on all documents, deadlines, notifications, etc., as well as having everything in one and single place (documents, communication, notifications, help for new CDPs, etc.).
 
 ## Presentation
 
-Jet-Centre is a kind of ERP that makes life easier for admins, both as CDP and in your position. First and foremost, it's a centralisation and automation tool. Centralisation in that all information and tools will be accessible from this tool, and automationin that you will only have to enter information once (e.g. to avoid rewriting the cient's information in the 10 BCs, or to write the same thing in a RM and a CE such as the layout of phases).
+Jet-Centre is a kind of ERP that makes life easier for admins, both as CDP and in your position. First and foremost, it's a centralisation and automation tool. Centralisation in that all information and tools will be accessible from this tool, and automation in that you will only have to enter information once (e.g. to avoid rewriting the client's information in the 10 BCs, or to write the same thing in a RM and a CE such as the layout of phases).
 
 For example, for the assignee selection, the CDP creates the MRI from the tool and the tool automatically creates the form. The answers to the MRI will automatically appear on the tool (cv + answers to the form) and put them in the follow-up folder, which means you can have all the information in one place without having to put everything in the study folder and open it each time. You can also decide to personalise things that weren't so great before, e.g. when filling in the interview form, only one CDP could answer at a time on the form, and you couldn't see in real time what the other CDP was writing.
 
-It will also help CDPs who are at the beginning of their mandate or who don't do a lot of studies. Having a checklist, tips on how to write documents, email templates, etc. For the time being, for a first version, we've concentrated mainly on the CDP aspect, so the specifics per job will come later. We only have mandatory features like MRI validation for secgé+dirco, the treasury page for treasury docs...
+It will also help CDPs who are at the beginning of their mandate or who don't do a lot of studies. Having a checklist, tips on how to write documents, email templates, etc. For the time being, for a first version, we've concentrated mainly on the CDP aspect, so the specifics per job will come later. We only have mandatory features like MRI validation for the General Secretary and the Commercial Director, the treasury page for treasury documents...
 
 It's a tool that would bring everything together in one place.
 
@@ -50,11 +50,11 @@ Here are the main goals of this tool:
     - LinkedIn/Emails for prospection.
 - Follow easily the KPIs with nice graphs.
 - Follow health and status of missions and departments.
-- Increase GPRD compliance.
+- Increase GDPR compliance.
 - Automate simple tasks
-- Remove repetitve tasks (e.g. fill a follow-up un tableau de suivi)
+- Remove repetitive tasks (e.g. fill a follow-up sheet)
 
-### Snapshots
+### Screenshots
 
 ![Mission follow](/docs/images/mission-follow.png)
 


### PR DESCRIPTION
The CIs are run by GitHub to enforce the branch rules, but also by the workflow files. This creates duplicate CIs that run in each PR. This PR removes these duplicated.

This PR also fixes the issue of `webiny/action-conventional-commits@v1.3.0` because it wasn't required in the branch rules (because of its name).
