### PR TITLE
fix(prisma): added missing binary target for prisma client

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,6 +5,7 @@
 /// Adds support and types for interacting with prisma from typescript.
 generator client {
     provider = "prisma-client-js"
+    binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 /// Indicates how to access the database.


### PR DESCRIPTION
Without this line, I cannot run `npx prisma generate` since Tom's latest pr #137.

I don't know why that's the case, because I never needed this line.

If this is wrong and should be fixed in some other way, or you have an explanation as to why this happened only now, feel free to comment !
