### PR TITLE
fix(study-pages): fix all the pages that didn't work

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -14,7 +14,6 @@ import Google, { GoogleProfile } from 'next-auth/providers/google';
 
 import prisma from '@/db';
 import { ROUTES } from '@/routes';
-import { dbg } from '@/lib/utils';
 
 async function getUserPosition(email: string): Promise<string | undefined> {
     try {

--- a/src/app/(user)/cdp/[study]/mri/figures.tsx
+++ b/src/app/(user)/cdp/[study]/mri/figures.tsx
@@ -33,7 +33,7 @@ export function getDomain(domain: Domain) {
 }
 
 export function getPay(wageLowerBound: number, wageUpperBound: number, pay_level: Level) {
-    const label = 'RÉMUNÉRATION';
+    const label = 'RÉTRIBUTION';
     const value = `${wageLowerBound}€ - ${wageUpperBound}€`;
 
     switch (pay_level) {

--- a/src/app/(user)/cdp/[study]/mri/form/form.tsx
+++ b/src/app/(user)/cdp/[study]/mri/form/form.tsx
@@ -21,17 +21,19 @@ import { MriFormType } from './schema';
 interface MRICreationProps {
     updateServer: () => void;
     form: UseFormReturn<MriFormType>;
+    setNotSaved: () => void;
 }
 
-export default function MRICreationForm({ form, updateServer }: MRICreationProps) {
+export default function MRICreationForm({ setNotSaved, form, updateServer }: MRICreationProps) {
     return (
         <FormProvider {...form}>
             <form>
-                <TitleEditor form={form} updateServer={updateServer} />
+                <TitleEditor setNotSaved={setNotSaved} form={form} updateServer={updateServer} />
                 <TextAreaFormElement
                     label="Introduction"
                     name="introductionText"
                     onBlur={() => updateServer()}
+                    onChange={setNotSaved}
                     form={form}
                     resizable
                 />
@@ -50,6 +52,7 @@ export default function MRICreationForm({ form, updateServer }: MRICreationProps
                         label="Rétribution basse"
                         name="wageLowerBound"
                         onBlur={() => updateServer()}
+                        onChange={setNotSaved}
                         type="number"
                         form={form}
                     />
@@ -58,6 +61,7 @@ export default function MRICreationForm({ form, updateServer }: MRICreationProps
                         label="Rétribution haute"
                         name="wageUpperBound"
                         onBlur={() => updateServer()}
+                        onChange={setNotSaved}
                         type="number"
                         form={form}
                     />
@@ -87,14 +91,23 @@ export default function MRICreationForm({ form, updateServer }: MRICreationProps
                     name="requiredSkillsText"
                     form={form}
                     onBlur={() => updateServer()}
+                    onChange={setNotSaved}
                     resizable
                 />
-                <TextAreaFormElement label="Échéances" name="timeLapsText" form={form} resizable />
+                <TextAreaFormElement
+                    onChange={setNotSaved}
+                    onBlur={() => updateServer()}
+                    label="Échéances"
+                    name="timeLapsText"
+                    form={form}
+                    resizable
+                />
                 <TextAreaFormElement
                     label="Description"
                     name="descriptionText"
                     form={form}
                     onBlur={() => updateServer()}
+                    onChange={setNotSaved}
                     resizable
                 />
             </form>
@@ -102,7 +115,7 @@ export default function MRICreationForm({ form, updateServer }: MRICreationProps
     );
 }
 
-function TitleEditor({ form, updateServer }: MRICreationProps) {
+function TitleEditor({ setNotSaved, form, updateServer }: MRICreationProps) {
     const [titleWarning, setTitleWarning] = useState(false);
     const [displayed, setDisplayed] = useState(false);
 
@@ -113,6 +126,7 @@ function TitleEditor({ form, updateServer }: MRICreationProps) {
                 name="title"
                 form={form}
                 onChange={() => {
+                    setNotSaved();
                     if (!displayed) {
                         setTitleWarning(true);
                         setDisplayed(true);

--- a/src/app/(user)/cdp/[study]/mri/form/schema.ts
+++ b/src/app/(user)/cdp/[study]/mri/form/schema.ts
@@ -45,7 +45,6 @@ export const DEFAULT_MRI_VALUES = {
 
 export function equalMri(left: MriFormType, right: MriFormType): boolean {
     return (
-        left.wageLowerBound == right.wageUpperBound &&
         left.wageLowerBound == right.wageLowerBound &&
         left.wageUpperBound == right.wageUpperBound &&
         left.wageLevel == right.wageLevel &&

--- a/src/app/(user)/cdp/[study]/mri/inner.tsx
+++ b/src/app/(user)/cdp/[study]/mri/inner.tsx
@@ -54,7 +54,12 @@ export default function Inner({ study, serverMriData }: InnerProps) {
 
     return (
         <div className="flex space-x-main h-full">
-            <UpdateBox status={status} update={updateServer} title="Écriture du MRI">
+            <UpdateBox
+                status={status}
+                update={updateServer}
+                title="Écriture du MRI"
+                editable={serverMriData.status === MriStatus.InProgress}
+            >
                 <MriEditorContent
                     setNotSaved={setNotSaved}
                     form={form}

--- a/src/app/(user)/info/users/user-editor.tsx
+++ b/src/app/(user)/info/users/user-editor.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import { useSession } from 'next-auth/react';
 import { useState } from 'react';
 
 import { Input } from '@/components/ui/input';
 
 import { getPosition, updatePosition } from './users';
-import { useSession } from 'next-auth/react';
 
 interface UserEditorProps {
     adminId: string;

--- a/src/app/(user)/suivi/create/actions.ts
+++ b/src/app/(user)/suivi/create/actions.ts
@@ -15,7 +15,7 @@ export async function createNewStudy(data: StudyCreationSchema) {
         data.settings.cdps.map(async (cdp) => {
             const person = await prisma.person.findUnique({
                 where: {
-                    name: cdp,
+                    name: { firstName: cdp.firstName, lastName: cdp.lastName },
                 },
                 select: {
                     user: true,
@@ -33,7 +33,7 @@ export async function createNewStudy(data: StudyCreationSchema) {
                 company.members.map(async (member) => {
                     const person = await prisma.person.findUnique({
                         where: {
-                            name: member,
+                            name: { firstName: member.firstName, lastName: member.lastName },
                         },
                     });
                     return { personId: person?.id ?? falseId, ...member };
@@ -61,7 +61,7 @@ export async function createNewStudy(data: StudyCreationSchema) {
                                         firstName: cdp.firstName,
                                         lastName: cdp.lastName,
                                         // If we don't connect, that means we have a new user
-                                        number: orUndefined((cdp as NewAdmin).tel),
+                                        phone_number: orUndefined((cdp as NewAdmin).tel),
                                     },
                                 },
                                 settings: {
@@ -108,7 +108,6 @@ export async function createNewStudy(data: StudyCreationSchema) {
                                                         email: member.email,
                                                         firstName: member.firstName,
                                                         lastName: member.lastName,
-                                                        number: '',
                                                     },
                                                 },
                                                 company: {
@@ -121,7 +120,6 @@ export async function createNewStudy(data: StudyCreationSchema) {
                                                             address,
                                                             companyInfos: {
                                                                 create: {
-                                                                    nvEmployees: 0,
                                                                     ca: orUndefined(company.ca),
                                                                     size: map(
                                                                         orUndefined(

--- a/src/app/(user)/suivi/edit-company/[companyId]/edit-employee.tsx
+++ b/src/app/(user)/suivi/edit-company/[companyId]/edit-employee.tsx
@@ -106,7 +106,7 @@ export function EditEmployee({
             <EditableCell value={job} setValue={setJob} setStatus={setStatus} update={update} />
             <TableCell className="p-0">
                 <div className="flex justify-around items-center">
-                    <BoxButtonIcon {...getUpdateBoxStatusInfos(status)} onClick={update} />
+                    <BoxButtonIcon {...getUpdateBoxStatusInfos(status, true)} onClick={update} />
                     <BoxButtonTrash onClick={removeEmployee} />
                 </div>
             </TableCell>

--- a/src/app/(user)/suivi/mri-validation/actions.ts
+++ b/src/app/(user)/suivi/mri-validation/actions.ts
@@ -33,7 +33,11 @@ export async function listMriToValidate() {
                 },
             },
             where: {
-                OR: [{ status: MriStatus.Finished }, { status: MriStatus.Validated }],
+                OR: [
+                    { status: MriStatus.Finished },
+                    { status: MriStatus.Validated },
+                    { status: MriStatus.Sent },
+                ],
             },
         });
     } catch (e) {

--- a/src/app/(user)/suivi/mri-validation/layout.tsx
+++ b/src/app/(user)/suivi/mri-validation/layout.tsx
@@ -5,6 +5,7 @@ import { Box, BoxContent, BoxHeader, BoxTitle } from '@/components/boxes/boxes';
 
 import { listMriToValidate } from './actions';
 import { ValidationButton } from './validation-button';
+import { MRI_VALIDATION } from '@/settings/sidebars/tabs';
 
 export default async function Layout({ children }: { children: ReactNode }) {
     const mris = (await listMriToValidate()) ?? [];
@@ -25,7 +26,9 @@ export default async function Layout({ children }: { children: ReactNode }) {
                                 <div className="p-2 w-full flex items-center" key={i}>
                                     <Link
                                         className="hover:underline w-full h-full"
-                                        href={'/mri-validation/' + mri.study.information.code}
+                                        href={
+                                            MRI_VALIDATION.href + '/' + mri.study.information.code
+                                        }
                                     >
                                         {mri.study.information.code +
                                             ' - ' +

--- a/src/app/(user)/suivi/mri-validation/layout.tsx
+++ b/src/app/(user)/suivi/mri-validation/layout.tsx
@@ -2,10 +2,10 @@ import Link from 'next/link';
 import { ReactNode } from 'react';
 
 import { Box, BoxContent, BoxHeader, BoxTitle } from '@/components/boxes/boxes';
+import { MRI_VALIDATION } from '@/settings/sidebars/tabs';
 
 import { listMriToValidate } from './actions';
 import { ValidationButton } from './validation-button';
-import { MRI_VALIDATION } from '@/settings/sidebars/tabs';
 
 export default async function Layout({ children }: { children: ReactNode }) {
     const mris = (await listMriToValidate()) ?? [];

--- a/src/components/boxes/update-box.tsx
+++ b/src/components/boxes/update-box.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
-import { FaBug, FaCheck, FaUser } from 'react-icons/fa6';
+import { FaBan, FaBug, FaCheck, FaUser } from 'react-icons/fa6';
 import { IoWarning } from 'react-icons/io5';
 import { IconType } from 'react-icons/lib';
 
@@ -69,7 +69,9 @@ interface StatusInfos {
  * @param {UpdateBoxStatus} status - The current status of the update box.
  * @returns {StatusInfos} The data needed to display the status.
  */
-export function getUpdateBoxStatusInfos(status: UpdateBoxStatus): StatusInfos {
+export function getUpdateBoxStatusInfos(status: UpdateBoxStatus, editable: boolean): StatusInfos {
+    if (!editable) return { Icon: FaBan, hoverContent: "Le contenu n'est plus modifiable" };
+
     switch (status) {
         case UpdateBoxStatus.Ok:
             return {
@@ -116,6 +118,8 @@ export function getUpdateBoxStatusInfos(status: UpdateBoxStatus): StatusInfos {
  * @property {UpdateBoxStatus} status - The current status of the update box, affecting the icon.
  * @property {() => void} update - Callback function triggered when the update icon is clicked.
  * @property {boolean} withBackdrop - Boolean to indicate if the box should have a backdrop.
+ * @property {boolean} editable - Boolean to indicate if the content can still be edited.
+ * This makes the update button clickable or not.
  */
 interface UpdateBoxProps {
     title: string;
@@ -123,6 +127,7 @@ interface UpdateBoxProps {
     status: UpdateBoxStatus;
     update: () => void;
     withBackdrop?: boolean;
+    editable?: boolean;
 }
 
 /**
@@ -137,6 +142,7 @@ export function UpdateBox({
     status,
     update,
     withBackdrop = true,
+    editable = true,
 }: UpdateBoxProps) {
     'use client';
     return (
@@ -144,7 +150,12 @@ export function UpdateBox({
             <BoxHeader>
                 <BoxTitle>{title}</BoxTitle>
                 <BoxHeaderBlock>
-                    <BoxButtonIcon {...getUpdateBoxStatusInfos(status)} onClick={update} />
+                    <BoxButtonIcon
+                        {...getUpdateBoxStatusInfos(status, editable)}
+                        onClick={() => {
+                            editable && update();
+                        }}
+                    />
                 </BoxHeaderBlock>
             </BoxHeader>
             <BoxContent>{children}</BoxContent>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -76,6 +76,8 @@ async function loggedInMiddleware(
 
     if (isNonAuthPublicRoute(pathname)) return NextResponse.next();
 
+    if (pathname.startsWith('/cdp/')) return NextResponse.next();
+
     if (!position || !(position in ROLES_SIDEBARS)) return rewrite(ROUTES.invalidPosition, request);
 
     const sidebar: RoleSideBar = ROLES_SIDEBARS[position as keyof typeof ROLES_SIDEBARS];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,7 +19,6 @@ import { redis } from './db';
 import { log } from './lib/utils';
 import { isAuthorisedToRoute, isNonAuthPublicRoute, ROUTES } from './routes';
 import { ROLES_SIDEBARS } from './settings/sidebars/sidebars';
-import { RoleSideBar } from './settings/sidebars/types';
 
 /**
  * Redirect current url onto another page.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,7 +17,7 @@ import type { Session } from 'next-auth';
 import { auth } from './actions/auth';
 import { redis } from './db';
 import { log } from './lib/utils';
-import { isNonAuthPublicRoute, ROUTES } from './routes';
+import { isAuthorisedToRoute, isNonAuthPublicRoute, ROUTES } from './routes';
 import { ROLES_SIDEBARS } from './settings/sidebars/sidebars';
 import { RoleSideBar } from './settings/sidebars/types';
 
@@ -76,14 +76,9 @@ async function loggedInMiddleware(
 
     if (isNonAuthPublicRoute(pathname)) return NextResponse.next();
 
-    if (pathname.startsWith('/cdp/')) return NextResponse.next();
-
     if (!position || !(position in ROLES_SIDEBARS)) return rewrite(ROUTES.invalidPosition, request);
 
-    const sidebar: RoleSideBar = ROLES_SIDEBARS[position as keyof typeof ROLES_SIDEBARS];
-    const isAuthorised = sidebar.sidebar.find((section) =>
-        section.items.find((item) => item.href === pathname)
-    );
+    const isAuthorised = isAuthorisedToRoute(pathname, position as keyof typeof ROLES_SIDEBARS);
 
     if (!isAuthorised) return rewrite(ROUTES.unauthorised, request);
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,6 @@
+import { ROLES_SIDEBARS } from '@/settings/sidebars/sidebars';
+import { RoleSideBar } from '@/settings/sidebars/types';
+
 const ERROR_PREFIX = '/error/';
 const AUTH_PREFIX = '/auth/';
 
@@ -15,6 +18,14 @@ export function isNonAuthPublicRoute(pathname: string) {
         if (pathname.startsWith(prefix)) return true;
 
     return false;
+}
+
+export function isAuthorisedToRoute(pathname: string, position: keyof typeof ROLES_SIDEBARS) {
+    if (pathname.startsWith('/cdp/')) return true;
+    const sidebar: RoleSideBar = ROLES_SIDEBARS[position];
+    return sidebar.sidebar.find((section) =>
+        section.items.find((item) => pathname.startsWith(item.href))
+    );
 }
 
 export const ROUTES = {


### PR DESCRIPTION
A bunch of fixes and improvements on the different pages that cover a study:

- **feat(info/users): auto-resync jwt to auto-reload permissions**
- **fix(create-study): prisma errors on study creation**
- **fix(middleware): give access to /cdp pages for all connected users**
- **fix(mri-creation): server check always returns false**
- **feat(mri-creation): mark the box as user-pending on input change**
- **fix(middleware): prefix determines access rights**
- **fix(mri-validation): hard-coded link is now incorrect**
- **feat(update-box): add a disabled state for when the box is not editable anymore**
- **feat(mri-validation): keep sent MRIs on validation page**
