### PR TITLE
chore(ci): run docs workflow only on main repository

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,6 @@ on:
     push:
         branches:
             - 'main'
-    pull_request:
-        branches:
-            - 'main'
 permissions:
     contents: write
 


### PR DESCRIPTION
## Description

When doing a pull request, the docs workflow shouldn't
try to deploy github pages to the original repository.
