### PR TITLE
chore(docker): cache bun downloads between builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache libc6-compat git openssl
 WORKDIR /app
 
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --verbose
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --verbose
 
 FROM base AS dev
 


### PR DESCRIPTION
## Description

When doing `make build` (or building the docker image manually), downloading all the packages takes quite a lot of time. With this caching technique, the build time are drastically improved and the stability is not compromised because corrupting this cache is very unlikely

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Chore
- [ ] Documentation update
- [ ] Performance upgrade

## Checklist

- [x] My code follows the style guidelines.
- [x] All tests pass.
- [x] The code is documented (if applicable).