### PR TITLE
fix(github): prisma doc on gh pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy doc to GItHub pages
+name: Deploy Prisma doc
 
 on:
     push:
@@ -15,7 +15,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
-            - name: Install Node.js
+            - name: Install Bun
               uses: oven-sh/setup-bun@v2
 
             - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
               run: bun x prisma generate
 
             - name: Deploy to GitHub Pages
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@v4
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: ./docs/schema

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,5 +18,5 @@ datasource db {
 /// It creates a web based documentation in the output folder.
 generator docs {
     provider = "node node_modules/prisma-docs-generator"
-    output   = "../../docs/schema"
+    output   = "../docs/schema"
 }


### PR DESCRIPTION
Prisma upgrade to 6.12 and refactor of file organisations seem to have broken the automatic deployment of the Prisma documentation, produced by the prisma-docs-generator.
