### PR TITLE
fix(prisma): prevent bun from automatically pulling the latest prisma

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,16 +42,16 @@ slogs:
 
 # Database
 generate:
-	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) bun x prisma generate
+	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) $(PREFIX) run generate
 
 reset-db:
-	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) bun x prisma migrate reset
+	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) $(PREFIX) run migrate:reset
 
 migrate-db:
-	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) bun x prisma migrate dev
+	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) $(PREFIX) run migrate:dev
 
 seed-db:
-	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) bun x prisma db seed -- --environment dev
+	$(COMPOSE) -f $(DEV_COMPOSE) exec $(APP_SERVICE_NAME) $(PREFIX) run db:seed:dev
 
 
 # Prod
@@ -65,7 +65,7 @@ down-prod:
 	$(COMPOSE) -f $(PROD_COMPOSE) down
 
 migrate-prod:
-	$(COMPOSE) -f $(PROD_COMPOSE) exec $(APP_SERVICE_NAME) bun x prisma migrate deploy
+	$(COMPOSE) -f $(PROD_COMPOSE) exec $(APP_SERVICE_NAME) $(PREFIX) run migrate:deploy
 
 deploy: build-prod up-prod
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
         "lint": "next lint",
         "prettier": "prettier",
         "fmt": "prettier -cw .",
-        "commitlint": "commitlint --from=HEAD~10 --to=HEAD"
+        "commitlint": "commitlint --from=HEAD~10 --to=HEAD",
+        "generate": "prisma generate",
+        "migrate:dev": "prisma migrate dev",
+        "migrate:deploy": "prisma migrate deploy",
+        "migrate:reset": "prisma migrate reset",
+        "db:seed:dev": "prisma db seed -- --environment dev"
     },
     "prisma": {
         "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
## Description

When running prisma via bunx it seems that the version of prisma present in package.json is automatically bumped to the latest version. This fixes it.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Chore
- [ ] Documentation update
- [ ] Performance upgrade

## Checklist

- [x] My code follows the style guidelines.
- [ ] All tests pass.
- [x] The code is documented (if applicable).