### PR TITLE
fix(github): pull request template shouldn't use task items for type

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@ Describe your changes in detail.
 
 ## Related Issue(s)
 
+<!-- Write  `fix #12` or `fixes 123` to automatically close the issue -->
+
 Link to the related issue(s) if applicable.
 
 ## Images
@@ -12,11 +14,14 @@ Paste images if applicable.
 
 ## Type of Change
 
-- [ ] New feature
-- [ ] Bug fix
-- [ ] Chore
-- [ ] Documentation update
-- [ ] Performance upgrade
+<!-- Keep only the lines that correspond to the PR -->
+
+- New feature
+- Bug fix
+- Chore
+- Documentation update
+- Performance upgrade
+- Refactor
 
 ## Checklist
 
@@ -24,6 +29,8 @@ Paste images if applicable.
 - [ ] All tests pass.
 - [ ] The code is documented (if applicable).
 
-## Breaking change
+## Breaking changes
 
-Indicate if your PR is breaking change (on a feature, on the database schema, etc.)
+<!-- Indicate if your PR is breaking change (on a feature, on the database schema, etc.) -->
+
+None


### PR DESCRIPTION
The template contains checkboxes in the PR for the type of PR, but those
are understood as tasks by GitHub, so the tasks will never be completed.
