### PR TITLE
fix(github): unified commit types between commits and prs

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -22,6 +22,7 @@ jobs:
                       chore
                       docs
                       style
+                      ref
                       refactor
                       perf
                       test
@@ -44,4 +45,4 @@ jobs:
 
             - uses: webiny/action-conventional-commits@v1.3.0
               with:
-                  allowed-commit-types: 'feat,fix,chore,docs,style,ref,perf,test'
+                  allowed-commit-types: 'feat,fix,chore,docs,style,ref,refactor,perf,test'


### PR DESCRIPTION
`ref` and `refactor` are now possible