### PR TITLE
chore(ci): fix workflow permission default permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build Next.js
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,5 +1,8 @@
 name: Enforce Conventional Commits
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,5 +1,8 @@
 name: Eslint
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,5 +1,8 @@
 name: Prettier formatting
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -1,5 +1,8 @@
 name: Knip Analysis
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/prisma-migrate.yml
+++ b/.github/workflows/prisma-migrate.yml
@@ -1,5 +1,8 @@
 name: Migrations
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/prisma-seed.yml
+++ b/.github/workflows/prisma-seed.yml
@@ -1,5 +1,8 @@
 name: Seed
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: pipeline
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -1,5 +1,8 @@
 name: verify-lockfile
 
+permissions:
+    contents: read
+
 on:
     pull_request:
     push:


### PR DESCRIPTION
Silences quality warnings on workflow files.

It is now recommended to add a `permissions` section in workflows for organisations.

Cf. https://github.com/Telecom-Etude/jet-centre/security/code-scanning/7